### PR TITLE
D-01183: Optimizing stats call

### DIFF
--- a/src/applications/ElementalChat/store/elementalChat.js
+++ b/src/applications/ElementalChat/store/elementalChat.js
@@ -131,17 +131,11 @@ export default {
     getStats: async ({ rootState, dispatch, commit }) => {
       log("Getting Stats...");
       commit("loadStats");
-      callZome(
-        dispatch,
-        rootState,
-        "chat",
-        "stats",
-        { category: "General" },
-        60000
-      )
+      callZome(dispatch, rootState, "chat", "agent_stats", null, 60000)
         .then(stats => {
           log("stats zomeCall done");
           console.log(">>>>>>>>>>>>>", stats);
+
           commit("setStats", stats);
         })
         .catch(error => {
@@ -533,8 +527,14 @@ export default {
       state.statsLoading = false;
       state.stats.agents = payload.agents;
       state.stats.active = payload.active;
-      state.stats.channels = payload.channels;
-      state.stats.messages = payload.messages;
+      // state.stats.channels = payload.channels;
+      // state.stats.messages = payload.messages;
+      state.stats.channels = state.channels.length;
+      let msgCount = 0;
+      state.channels.forEach(c => {
+        if (c.messages !== undefined) msgCount += c.messages.length;
+      });
+      state.stats.messages = msgCount;
     },
     resetStats(state) {
       state.showStats = undefined;

--- a/src/applications/ElementalChat/store/elementalChat.js
+++ b/src/applications/ElementalChat/store/elementalChat.js
@@ -134,7 +134,7 @@ export default {
       callZome(dispatch, rootState, "chat", "agent_stats", null, 60000)
         .then(stats => {
           log("stats zomeCall done");
-          console.log("Agent stats", stats);
+          console.log("Peer stats", stats);
           commit("setStats", stats);
         })
         .catch(error => {

--- a/src/applications/ElementalChat/store/elementalChat.js
+++ b/src/applications/ElementalChat/store/elementalChat.js
@@ -134,8 +134,7 @@ export default {
       callZome(dispatch, rootState, "chat", "agent_stats", null, 60000)
         .then(stats => {
           log("stats zomeCall done");
-          console.log(">>>>>>>>>>>>>", stats);
-
+          console.log("Agent stats", stats);
           commit("setStats", stats);
         })
         .catch(error => {
@@ -527,8 +526,6 @@ export default {
       state.statsLoading = false;
       state.stats.agents = payload.agents;
       state.stats.active = payload.active;
-      // state.stats.channels = payload.channels;
-      // state.stats.messages = payload.messages;
       state.stats.channels = state.channels.length;
       let msgCount = 0;
       state.channels.forEach(c => {

--- a/src/applications/ElementalChat/views/ElementalChat.vue
+++ b/src/applications/ElementalChat/views/ElementalChat.vue
@@ -124,7 +124,7 @@
         <v-card-text v-if="!statsAreLoading">
           <v-row align="center">
             <v-col class="display-1" cols="6">
-              Total agents:
+              Total peers:
             </v-col>
             <v-col class="display-1" cols="6">
               {{ stats.agents == undefined ? "--" : stats.agents }} 👤
@@ -132,7 +132,7 @@
           </v-row>
           <v-row align="center">
             <v-col class="display-1" cols="6">
-              Active agents:
+              Active peers:
             </v-col>
             <v-col class="display-1" cols="6">
               {{ stats.active == undefined ? "--" : stats.active }} 👤


### PR DESCRIPTION
## Optimization thoughts:
We do not need to get the number of channels and messages for stats since we pull all the channels and messages every-time on pulling anyway.
So we can assume that we have almost all the channels and messages already in the state.
**This means we need to make a zome call to only get the number of agents.**