### PR TITLE
Use specific chatters for signalling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Vue based user interface for [elemental-chat dna](/holochain/elemental-chat)
 1. Assuming you have all of the above installed as per their readme's and the dna has been installed and built, you can fire everything up with:
    1. In one terminal window install and run the dna with with `holochain-run-dna` like this:
 ```
-holochain-run-dna -i elemental-chat:alpha14 -u kitsune-proxy://CIW6PxKxsPPlcuvUCbMcKwUpaMSmB7kLD8xyyj4mqcw/kitsune-quic/h/proxy.holochain.org/p/5778/-- ../elemental-chat/elemental-chat.dna.gz
+holochain-run-dna -i elemental-chat:alpha19 -u kitsune-proxy://CIW6PxKxsPPlcuvUCbMcKwUpaMSmB7kLD8xyyj4mqcw/kitsune-quic/h/proxy.holochain.org/p/5778/-- ../elemental-chat/elemental-chat.dna.gz
 ```
   1. In another terminal window serve the UI with:
 ``` shell

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elemental-chat-ui",
-  "version": "0.0.1-alpha20",
+  "version": "0.0.1-alpha24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elemental-chat-ui",
-  "version": "0.0.1-alpha23",
+  "version": "0.0.1-alpha24",
   "private": true,
   "scripts": {
     "serve:dev-agent-1": "VUE_APP_WEB_CLIENT_PORT=8888 yarn serve:develop",

--- a/src/applications/ElementalChat/store/elementalChat.js
+++ b/src/applications/ElementalChat/store/elementalChat.js
@@ -121,7 +121,7 @@ function getRecentChatters(me, channel) {
     // when to stop going backward in the history looking for people too send to
     if (
       now - new Date(msg.createdAt[0] * 1000) > MAX_MESSAGE_AGE_FOR_SIGNAL &&
-      count > MIN_CHATTERS_FOR_SIGNAL
+      count >= MIN_CHATTERS_FOR_SIGNAL
     ) {
       break;
     }

--- a/src/applications/ElementalChat/store/elementalChat.js
+++ b/src/applications/ElementalChat/store/elementalChat.js
@@ -105,20 +105,23 @@ function _addMessageToChannel(rootState, commit, state, channel, message) {
 }
 
 const MAX_CHATTERS_FOR_SIGNAL = 100;
-const MAX_MESSAGE_AGE_FOR_SIGNAL = 10000; // * 60 * 60 * 24 // 1 day
-const MIN_CHATTERS_FOR_SIGNAL = 10; // even if older than a day
+const MAX_MESSAGE_AGE_FOR_SIGNAL = 1000 * 60 * 60 * 24; // 1 day
+const MIN_CHATTERS_FOR_SIGNAL = 10; // min number of chatters to send to even if older than a day
 function getRecentChatters(me, channel) {
   let chatters = {};
   const now = Date.now();
   const meStr = arrayBufferToBase64(me);
   for (let i = channel.messages.length - 1; i > 0; i--) {
     const msg = channel.messages[i];
-    if (chatters.length > MAX_CHATTERS_FOR_SIGNAL) {
+    const count = Object.keys(chatters).length;
+    // absolute count limit on who to send signals to
+    if (count > MAX_CHATTERS_FOR_SIGNAL) {
       break;
     }
+    // when to stop going backward in the history looking for people too send to
     if (
       now - new Date(msg.createdAt[0] * 1000) > MAX_MESSAGE_AGE_FOR_SIGNAL &&
-      chatters.length > MIN_CHATTERS_FOR_SIGNAL
+      count > MIN_CHATTERS_FOR_SIGNAL
     ) {
       break;
     }
@@ -127,7 +130,7 @@ function getRecentChatters(me, channel) {
       chatters[agentStr] = msg.createdBy;
     }
   }
-  console.log("chatters", Object.values(chatters));
+  console.log("chatters for signals:", Object.values(chatters));
   return Object.values(chatters);
 }
 

--- a/src/applications/ElementalChat/store/elementalChat.js
+++ b/src/applications/ElementalChat/store/elementalChat.js
@@ -130,7 +130,7 @@ function getRecentChatters(me, channel) {
       chatters[agentStr] = msg.createdBy;
     }
   }
-  console.log("chatters for signals:", Object.values(chatters));
+  console.log("chatters to be signaled:", Object.values(chatters));
   return Object.values(chatters);
 }
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -25,8 +25,8 @@ const RECONNECT_SECONDS = 15;
 
 const APP_VERSION = process.env.VUE_APP_UI_VERSION;
 
-const DNA_VERSION = "alpha17";
-const DNA_UUID = "0002";
+const DNA_VERSION = "alpha19";
+const DNA_UUID = "0001";
 
 const INSTALLED_APP_ID =
   // for development/testing: dev agent 1 is served at port 8888, and dev agent 2 at port 9999


### PR DESCRIPTION
Now send signals only to recent chatters in the a channel's history rather than to all active agents, except in the case that there isn't any history.