### PR TITLE
Remove signin signup workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@holo-host/web-sdk": "Holo-Host/web-sdk#e59a0ce5d2f794127b2d932f7aa6b20c39e48f47",
+    "@holo-host/web-sdk": "Holo-Host/web-sdk#5fa40735b120ce7a76cee0a40fa94a3fc1f6f648",
     "@holochain/conductor-api": "0.0.1-dev.14",
     "async-wait-until": "^1.2.6",
     "core-js": "^3.6.5",

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -130,7 +130,6 @@ const initializeAppHolo = async (commit, dispatch, state) => {
         logo_url: "img/ECLogoWhiteMiddle.png",
         app_name: "Elemental Chat",
         info_link: "https://holo.host/faq-tag/elemental-chat"
-        // publisher_name: "Holo"
       }
     );
     holoClient = createHoloClient(webSdkConnection);

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -130,6 +130,7 @@ const initializeAppHolo = async (commit, dispatch, state) => {
         logo_url: "img/ECLogoWhiteMiddle.png",
         app_name: "Elemental Chat",
         info_link: "https://holo.host/faq-tag/elemental-chat"
+        // publisher_name: "Holo"
       }
     );
     holoClient = createHoloClient(webSdkConnection);
@@ -146,15 +147,9 @@ const initializeAppHolo = async (commit, dispatch, state) => {
   }
 
   if (!state.isHoloSignedIn) {
-    const createAccount = window.confirm("Create a new account?");
     try {
-      if (createAccount) {
-        await holoClient.signUp();
-        commit("setIsHoloSignedIn", true);
-      } else {
-        await holoClient.signIn();
-        commit("setIsHoloSignedIn", true);
-      }
+      await holoClient.signIn();
+      commit("setIsHoloSignedIn", true);
     } catch (e) {
       commit("setIsChaperoneDisconnected", true);
       return;


### PR DESCRIPTION
Depends on https://github.com/Holo-Host/chaperone/pull/107

Previously you were given a confirmation dialog in order to choose between sign in and sign up, with the linked PR, that functionality is implemented in Chaperone so we can remove that logic