### PR TITLE
Improve Holo DNA alias logic

### DIFF
--- a/src/consts.js
+++ b/src/consts.js
@@ -21,8 +21,3 @@ export const WEB_CLIENT_URI =
   isHoloHosted() || isHoloSelfHosted()
     ? `wss://${window.location.hostname}/api/v1/ws/`
     : `ws://localhost:${WEB_CLIENT_PORT}`
-
-// this dna_alias should be whatever is set in HHA
-// export const HOLO_DNA_ALIAS = 'uhCkkmrkoAHPVf_eufG7eC5fm6QKrW5pPMoktvG5LOC0SnJ4vV1Uv-0'
-
-export const HOLO_DNA_ALIAS = 'elemental-chat.dna.gz'

--- a/src/store/callZome.js
+++ b/src/store/callZome.js
@@ -1,9 +1,8 @@
 import { isHoloHosted, log } from '@/utils'
-import { HOLO_DNA_ALIAS } from '@/consts'
 
 const callZomeHolo = (_, state, zomeName, fnName, payload) =>
   state.holoClient.zomeCall(
-    HOLO_DNA_ALIAS,
+    state.dnaAlias,
     zomeName,
     fnName,
     payload)

--- a/src/store/holochain.js
+++ b/src/store/holochain.js
@@ -6,8 +6,7 @@ import {
   APP_VERSION,
   INSTALLED_APP_ID,
   WEB_CLIENT_PORT,
-  WEB_CLIENT_URI,
-  HOLO_DNA_ALIAS
+  WEB_CLIENT_URI
 } from '@/consts'
 import { arrayBufferToBase64 } from './utils'
 import { handleSignal } from './elementalChat'
@@ -15,7 +14,6 @@ import { handleSignal } from './elementalChat'
 console.log('process.env.VUE_APP_CONTEXT : ', process.env.VUE_APP_CONTEXT)
 console.log('INSTALLED_APP_ID : ', INSTALLED_APP_ID)
 console.log('WEB_CLIENT_URI : ', WEB_CLIENT_URI)
-console.log('HOLO_DNA_ALIAS : ', HOLO_DNA_ALIAS)
 
 // We can't store the webSdkConnection object directly in vuex, so store this wrapper instead
 function createHoloClient (webSdkConnection) {

--- a/src/store/holochain.js
+++ b/src/store/holochain.js
@@ -57,7 +57,7 @@ const initializeClientHolo = async (commit, dispatch, state) => {
   }
 
   const appInfo = await holoClient.appInfo()
-  const [cell] = appInfo
+  const [cell] = appInfo.cell_data
   const [cellId, dnaAlias] = cell
   commit('setHoloClientAndDnaAlias', holoClient, dnaAlias)
   const [dnaHash] = cellId

--- a/src/store/holochain.js
+++ b/src/store/holochain.js
@@ -151,6 +151,7 @@ export default {
     reconnectingIn: 0,
     appInterface: null,
     dnaHash: null,
+    dnaAlias: null,
     firstConnect: false,
     agentKey: null
   },
@@ -204,6 +205,7 @@ export default {
       state.firstConnect = false
     },
     setHoloClientAndDnaAlias (state, holoClient, dnaAlias) {
+      state.dnaAlias = dnaAlias
       state.holoClient = holoClient
       state.conductorDisconnected = false
       state.reconnectingIn = -1

--- a/src/store/holochain.js
+++ b/src/store/holochain.js
@@ -59,7 +59,7 @@ const initializeClientHolo = async (commit, dispatch, state) => {
   const appInfo = await holoClient.appInfo()
   const [cell] = appInfo.cell_data
   const [cellId, dnaAlias] = cell
-  commit('setHoloClientAndDnaAlias', holoClient, dnaAlias)
+  commit('setHoloClientAndDnaAlias', { holoClient, dnaAlias })
   const [dnaHash] = cellId
   commit('setDnaHash', 'u' + Buffer.from(dnaHash).toString('base64'))
 
@@ -205,7 +205,8 @@ export default {
       state.reconnectingIn = -1
       state.firstConnect = false
     },
-    setHoloClientAndDnaAlias (state, holoClient, dnaAlias) {
+    setHoloClientAndDnaAlias (state, payload) {
+      const { holoClient, dnaAlias } = payload
       state.dnaAlias = dnaAlias
       state.holoClient = holoClient
       state.conductorDisconnected = false

--- a/src/store/holochain.js
+++ b/src/store/holochain.js
@@ -47,7 +47,12 @@ const initializeClientHolo = async (commit, dispatch, state) => {
       }
     )
     holoClient = createHoloClient(webSdkConnection)
-    commit('setHoloClient', holoClient)
+    const appInfo = await holoClient.appInfo()
+    const [cell] = appInfo
+    const [cellId, dnaAlias] = cell
+    commit('setHoloClientAndDnaAlias', holoClient, dnaAlias)
+    const [dnaHash] = cellId
+    commit('setDnaHash', 'u' + Buffer.from(dnaHash).toString('base64'))
   } else {
     holoClient = state.holoClient
   }
@@ -68,10 +73,6 @@ const initializeClientHolo = async (commit, dispatch, state) => {
       return
     }
   }
-
-  const appInfo = await holoClient.appInfo()
-  const cellId = appInfo.cell_data[0][0]
-  commit('setDnaHash', 'u' + Buffer.from(cellId[0]).toString('base64'))
 
   isInitializingHolo = false
 }
@@ -204,8 +205,8 @@ export default {
       state.reconnectingIn = -1
       state.firstConnect = false
     },
-    setHoloClient (state, payload) {
-      state.holoClient = payload
+    setHoloClientAndDnaAlias (state, holoClient, dnaAlias) {
+      state.holoClient = holoClient
       state.conductorDisconnected = false
       state.reconnectingIn = -1
       state.firstConnect = false

--- a/src/store/holochain.js
+++ b/src/store/holochain.js
@@ -45,12 +45,6 @@ const initializeClientHolo = async (commit, dispatch, state) => {
       }
     )
     holoClient = createHoloClient(webSdkConnection)
-    const appInfo = await holoClient.appInfo()
-    const [cell] = appInfo
-    const [cellId, dnaAlias] = cell
-    commit('setHoloClientAndDnaAlias', holoClient, dnaAlias)
-    const [dnaHash] = cellId
-    commit('setDnaHash', 'u' + Buffer.from(dnaHash).toString('base64'))
   } else {
     holoClient = state.holoClient
   }
@@ -61,6 +55,13 @@ const initializeClientHolo = async (commit, dispatch, state) => {
     commit('setIsChaperoneDisconnected', true)
     return
   }
+
+  const appInfo = await holoClient.appInfo()
+  const [cell] = appInfo
+  const [cellId, dnaAlias] = cell
+  commit('setHoloClientAndDnaAlias', holoClient, dnaAlias)
+  const [dnaHash] = cellId
+  commit('setDnaHash', 'u' + Buffer.from(dnaHash).toString('base64'))
 
   if (!state.isHoloSignedIn) {
     try {


### PR DESCRIPTION
On `develop`, hosted EC UI doesn't work because the dna_alias has been set to `elemental-chat.dna.gz`, which is correct when you're using `holochain-run-dna` and local HCC mode chaperone, but is not correct when you're using HPOS because the value defined in HHA is `elemental-chat`. This changes the logic to be adaptive to whatever environment