### PR TITLE
Identicon type check, and don't send signals to yourself

### DIFF
--- a/src/identicon.js
+++ b/src/identicon.js
@@ -2,7 +2,7 @@ let bytes = [0]
 let byteIndex = 0
 
 function setBytes (hash) {
-  bytes = hash
+  bytes = hash || []
   // byteIndex = hash[hash.length - 1] % hash.length // set the starting point
   byteIndex = 0
 }
@@ -86,6 +86,10 @@ function buildOpts (opts) {
 // For now we're moving on to more pressing things but this should be addressed before using the code in a production UI
 
 export default function renderIcon (opts, canvas) {
+  if (opts.hash && !(opts.hash instanceof Uint8Array)) {
+    throw new Error('invalid type for opts.hash, expecting Uint8Array or null')
+  }
+
   opts = buildOpts(opts || {})
   const { size, backgroundColor } = opts
 

--- a/src/store/elementalChat.js
+++ b/src/store/elementalChat.js
@@ -365,7 +365,7 @@ export default {
     }
   },
   getters: {
-    channel: state => {
+    channel: (state, _, { holochain: { agentKey } }) => {
       const emptyChannel = {
         info: { name: '' },
         entry: { category: 'General', uuid: '' },
@@ -384,6 +384,7 @@ export default {
       }
 
       const activeChatters = uniqBy((channel.messages || []).map(message => message.createdBy), arrayBufferToBase64)
+        .filter(userIdBuffer => arrayBufferToBase64(userIdBuffer) !== arrayBufferToBase64(agentKey))
 
       return {
         ...channel,


### PR DESCRIPTION
Adds a type check of `opts.hash` for the identicon generation code, to give us better error messages.

Prevents the UI from sending signals to the user from their own messages