### PR TITLE
D-01240 Profile prompt bug fix

### DIFF
--- a/src/store/callZome.js
+++ b/src/store/callZome.js
@@ -1,8 +1,8 @@
 import { isHoloHosted, log } from '@/utils'
-import { logZomeCall, actionType } from '@/store/utils'
+import { logZomeCall, actionType, UndefinedClientError } from '@/store/utils'
 
 const callZomeHolo = (_, state, zomeName, fnName, payload) => {
-  if (!state.holoClient) throw new Error('Attempted callZomeHolo before holoClient is defined')
+  if (!state.holoClient) throw new UndefinedClientError('Attempted callZomeHolo before holoClient is defined')
   return state.holoClient.zomeCall(
     state.dnaAlias,
     zomeName,
@@ -11,7 +11,7 @@ const callZomeHolo = (_, state, zomeName, fnName, payload) => {
 }
 
 const callZomeLocal = async (_, state, zomeName, fnName, payload, timeout) => {
-  if (!state.holochainClient) throw new Error('Attempted callZomeLocal before holochainClient is defined')
+  if (!state.holochainClient) throw new UndefinedClientError('Attempted callZomeLocal before holochainClient is defined')
   return state.holochainClient.callZome({
     cap: null,
     cell_id: state.appInterface.cellId,
@@ -59,6 +59,9 @@ export const callZome = async (dispatch, rootState, zomeName, fnName, payload, t
     log(`${zomeName}.${fnName} ERROR: callZome threw error`, e)
     if (e === 'Error: Socket is not open') {
       return dispatch('resetConnectionState', null, { root: true })
+    }
+    if (e instanceof UndefinedClientError) {
+      throw e
     }
   } finally {
     dispatch('holochain/callIsNotLoading', fnName, { root: true })

--- a/src/store/elementalChat.js
+++ b/src/store/elementalChat.js
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid'
 import { uniqBy } from 'lodash'
 import { toUint8Array, log } from '@/utils'
-import { arrayBufferToBase64, retryIfSourceChainHeadMoved } from './utils'
+import { arrayBufferToBase64, retryIfSourceChainHeadMoved, retryUntilClientIsDefined } from './utils'
 import { callZome } from './callZome'
 
 function pollMessages (dispatch, activeChatter, channel) {
@@ -319,7 +319,7 @@ export default {
       commit('setAgentHandle', payload)
     },
     async getProfile ({ commit, dispatch, rootState }) {
-      const profile = await callZome(dispatch, rootState, 'profile', 'get_my_profile', null, 30000)
+      const profile = await retryUntilClientIsDefined(() => callZome(dispatch, rootState, 'profile', 'get_my_profile', null, 30000))
       if (profile && profile.nickname) {
         commit('setAgentHandle', profile.nickname)
       } else {

--- a/src/store/holochain.js
+++ b/src/store/holochain.js
@@ -39,6 +39,7 @@ function createHoloClient (webSdkConnection) {
 let isInitializingHolo = false
 const initializeClientHolo = async (commit, dispatch, state) => {
   if (isInitializingHolo) return
+
   isInitializingHolo = true
   let holoClient
 

--- a/src/store/utils.js
+++ b/src/store/utils.js
@@ -1,3 +1,5 @@
+import wait from 'waait'
+
 export const arrayBufferToBase64 = buffer => {
   let binary = ''
   const bytes = new Uint8Array(buffer)
@@ -38,9 +40,34 @@ export const retryIfSourceChainHeadMoved = async call => {
     console.log('isHeadMovedError', isHeadMovedError)
     if (isHeadMovedError) {
       intervalMs *= (2 + Math.random())
-      await delay(intervalMs)
+      await wait(intervalMs)
     } else {
       return val
+    }
+  }
+}
+
+export class UndefinedClientError extends Error {
+  constructor (message) {
+    super(message)
+    this.name = 'UndefinedClientError'
+  }
+}
+
+export const retryUntilClientIsDefined = async (call, maxTries = 20) => {
+  let tries = 0
+  while (true) {
+    let val
+    try {
+      tries++
+      val = await call()
+      return val
+    } catch (e) {
+      if (e instanceof UndefinedClientError && tries < maxTries) {
+        await wait(500)
+      } else {
+        return val
+      }
     }
   }
 }


### PR DESCRIPTION
When calling `get_profile`, this catches the error thrown if the client is not connected yet, and keeps trying until the client is connected.

Without this, on refresh the initial `get_profile` call threw an error so the Nickname prompt was displayed, even if you had previously set your nickname