### PR TITLE
Vertically center title in header

### DIFF
--- a/src/ElementalChat.vue
+++ b/src/ElementalChat.vue
@@ -3,7 +3,7 @@
     <v-app-bar app dense dark tile elevation="5" aria-label="App Bar">
       <v-toolbar-title class="title pl-0 no-wrap">
         <img src="@/assets/chat.png" class="title-logo" aria-label="Elemental Chat Logo"/>
-        <p role="title"  aria-label="Page Title"> Elemental Chat {{ channel.info.name ? "- " + channel.info.name : "" }} </p>
+        <div role="title"  aria-label="Page Title"> Elemental Chat {{ channel.info.name ? "- " + channel.info.name : "" }} </div>
       </v-toolbar-title>
       <v-spacer></v-spacer>
 


### PR DESCRIPTION
The margin that gets automatically added to the `<p>` element was making the title ("Elemental Chat - Channel name!") too high up. Changing it to a div lets it be centered like the Elemental Chat logo.