### PR TITLE
Remove extra padding underneath newest message

### DIFF
--- a/src/components/Messages.vue
+++ b/src/components/Messages.vue
@@ -84,6 +84,9 @@ export default {
   overflow-y: auto;
   height: calc(100vh - 218px);
 }
+.chat-container#container > ul {
+  padding-bottom: 0px !important;
+}
 .my-message {
   background-color: red;
 }


### PR DESCRIPTION
This was causing there to be an extra blank space between the newest 
message and the chat box, which would show if you scrolled all the way 
down in the messages.

The CSS selector is so specific because we need to override 
`padding-bottom: 40px !important;` which comes from Vue I think. More 
about `!important` 
https://stackoverflow.com/questions/11178673/how-to-override-important