### PR TITLE
Switch autodeploy to yarn

### DIFF
--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -11,9 +11,9 @@ jobs:
     name: Deploy
     steps:
       - uses: actions/checkout@v2
-      - run: npm ci
+      - run: yarn install --frozen-lockfile
       - name: Build site
-        run: 'npm run build:holo-dev'
+        run: yarn run build:holo-dev
       - name: Publish to DevNet
         uses: cloudflare/wrangler-action@1.1.0
         with:

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -11,9 +11,9 @@ jobs:
     name: Deploy
     steps:
       - uses: actions/checkout@v2
-      - run: npm ci
+      - run: yarn install --frozen-lockfile
       - name: Build site
-        run: 'npm run build:holo-host'
+        run: yarn run build:holo-host
       - name: Publish to MainNet
         uses: cloudflare/wrangler-action@1.1.0
         with:

--- a/.github/workflows/deploy-to-scaletest.yml
+++ b/.github/workflows/deploy-to-scaletest.yml
@@ -11,9 +11,9 @@ jobs:
     name: Deploy
     steps:
       - uses: actions/checkout@v2
-      - run: npm ci
+      - run: yarn install --frozen-lockfile
       - name: Build site
-        run: 'npm run build:holo-scale-test'
+        run: yarn run build:holo-scale-test
       - name: Publish to DevNet
         uses: cloudflare/wrangler-action@1.1.0
         with:

--- a/scripts/release-builds.sh
+++ b/scripts/release-builds.sh
@@ -2,7 +2,7 @@
 build () {
     export VUE_APP_DNA_VERSION=$1
     export VUE_APP_DNA_UID=$2
-    npm run build:self-hosted
+    yarn run build:self-hosted
     cd dist
     rm service-worker.js
     zip -r elemental-chat.zip .


### PR DESCRIPTION
The old npm setup required having a `package-lock.json` in addition to `yarn.lock` in the repo, which seems bad. @peeech was there a reason you introduced npm in addition to yarn in the first place?