### PR TITLE
added correct URL per Joel

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:happ": "sh ./scripts/build-bundle.sh",
     "run:conductor": "hc sandbox clean && hc sandbox generate ./tests/integration/setup/bundle/elemental-chat.happ -r=8888 -a='elemental-chat:alpha19:0001'",
     "build:holo-host": "VUE_APP_UI_VERSION=$npm_package_version VUE_APP_CONTEXT='holo-host' VUE_APP_CHAPERONE_SERVER_URL='https://chaperone.holo.host/' vue-cli-service build",
-    "build:holo-dev": "VUE_APP_UI_VERSION=$npm_package_version VUE_APP_CONTEXT='holo-host' VUE_APP_CHAPERONE_SERVER_URL='https://devnet-chaperone.holo.host/' vue-cli-service build --mode development",
+    "build:holo-dev": "VUE_APP_UI_VERSION=$npm_package_version VUE_APP_CONTEXT='holo-host' VUE_APP_CHAPERONE_SERVER_URL='https://chaperone-rsm.devnet.holotest.net' vue-cli-service build --mode development",
     "build:holo-test": "VUE_APP_ANONYMOUS='enabled' VUE_APP_UI_VERSION=$npm_package_version VUE_APP_CONTEXT='holo-host' VUE_APP_CHAPERONE_SERVER_URL='http://localhost:24274' vue-cli-service build --mode development",
     "build:holo-scale-test": "VUE_APP_UI_VERSION=$npm_package_version VUE_APP_CONTEXT='holo-host' VUE_APP_CHAPERONE_SERVER_URL='https://scaletest-chaperone.holo.host/' vue-cli-service build",
     "build:self-hosted": "VUE_APP_UI_VERSION=$npm_package_version VUE_APP_CONTEXT='self-hosted' vue-cli-service build",


### PR DESCRIPTION
Dev testing is currently blocked for Publisher Alpha. The problem is likely a result of the wrong chaperone URL being supplied in package.json for the develop. This PR simply updates the build commands for dev to use the correct chaperone.